### PR TITLE
Fix apifallback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,10 +3,12 @@ import Home from "./pages/Home";
 import About from "./pages/About";
 import Projects from "./pages/Projects";
 import Contact from "./pages/Contact";
+import Navbar from "./components/NavBar";
 
 export default function App() {
   return (
     <Router>
+      <Navbar />
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/about" element={<About />} />

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+
+export default function Navbar() {
+  return (
+    <nav className="bg-gray-800 text-white fixed w-full top-0 left-0 z-10 shadow-md">
+      <div className="max-w-6xl mx-auto p-4 flex justify-between items-center">
+        <div className="text-2xl font-semibold">My Portfolio</div>
+        <div className="space-x-4">
+          <Link to="/" className="hover:text-gray-300">
+            Home
+          </Link>
+          <Link to="/about" className="hover:text-gray-300">
+            About
+          </Link>
+          <Link to="/projects" className="hover:text-gray-300">
+            Projects
+          </Link>
+          <Link to="/contact" className="hover:text-gray-300">
+            Contact
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,4 +1,10 @@
+import { useEffect } from "react";
+
 const About = () => {
+  useEffect(() => {
+    document.title = "About Samson";
+  }, []);
+
   return (
     <div>
       <p>About Samson</p>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,4 +1,10 @@
+import { useEffect } from "react";
+
 const Contact = () => {
+  useEffect(() => {
+    document.title = "Contact";
+  }, []);
+
   return (
     <div>
       <p>Contact Samson</p>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,10 @@
+import { useEffect } from "react";
+
 const Home = () => {
+  useEffect(() => {
+    document.title = "Samson's Portfolio";
+  }, []);
+
   return (
     <div>
       <p>Samson's portfolio</p>

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -1,4 +1,10 @@
+import { useEffect } from "react";
+
 const Projects = () => {
+  useEffect(() => {
+    document.title = "My Projects";
+  }, []);
+
   return (
     <div>
       <p>Samson's projects</p>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,11 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-})
+  server: {
+    historyApiFallback: true,
+  },
+});


### PR DESCRIPTION
## fix: handle direct route access in React Router setup

This PR resolves an issue where accessing routes like `/about`, `/contact`, or `/projects` directly would result in a 404 error. The server was attempting to locate physical files (e.g., `about/index.html`), but these paths are actually handled client-side by React Router.

### 🛠 Solution:
Configured routing fallback to ensure all routes serve `index.html`, allowing React to take over and properly render the correct page.
